### PR TITLE
Add click event to emits

### DIFF
--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -25,7 +25,7 @@ export default (ComponentStyle) => {
         ...combinedPropDefinition
       },
 
-      emits: ['input', 'update:modelValue'],
+      emits: ['input', 'update:modelValue', 'click'],
 
       setup (props, { slots, attrs, emit }) {
         const theme = inject('theme')
@@ -58,6 +58,9 @@ export default (ComponentStyle) => {
               onInput: (e) => {
                 emit('update:modelValue', e.target.value)
                 emit('input', e)
+              },
+              onClick: (e) => {
+                emit('click', e)
               }
             },
             slots


### PR DESCRIPTION
Lot of times you need to track click on styled components, This PR just add click event to emits prop of styled component.