### PR TITLE
Add a support for reactive theme

### DIFF
--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -1,4 +1,4 @@
-import { h, inject } from 'vue'
+import { computed, h, inject } from 'vue'
 import css from '../constructors/css'
 import isVueComponent from '../utils/isVueComponent'
 import normalizeProps from '../utils/normalizeProps'
@@ -30,8 +30,10 @@ export default (ComponentStyle) => {
       setup (props, { slots, attrs, emit }) {
         const theme = inject('theme')
 
+        const finalTheme = computed(() => theme && theme.value ? theme.value : theme)
+
         return () => {
-          const styleClass = componentStyle.generateAndInjectStyles({ theme, ...props, ...attrs })
+          const styleClass = componentStyle.generateAndInjectStyles({ theme: finalTheme.value, ...props, ...attrs })
           const classes = [styleClass]
 
           if (attrs.class) {

--- a/src/providers/ThemeProvider.js
+++ b/src/providers/ThemeProvider.js
@@ -1,11 +1,13 @@
-import { h, provide } from 'vue'
+import { h, provide, toRefs } from 'vue'
 
 export default {
   props: {
     theme: Object
   },
-  setup (props, { slots }) {
-    provide('theme', props.theme)
+  setup (props) {
+    const { theme } = toRefs(props)
+
+    provide('theme', theme)
   },
 
   render () {


### PR DESCRIPTION
Currently theme injection is not reactive.

Note: These changes have made the theme variable reactive, which means that we now need to use `.value` when accessing the theme in the `Setup` function.